### PR TITLE
Add the ability to select replay from the Simulation Session Table.

### DIFF
--- a/src/components/DriverViewPage/DriverViewPage.tsx
+++ b/src/components/DriverViewPage/DriverViewPage.tsx
@@ -1,8 +1,9 @@
 import './DriverViewPage.css';
 import { fetchAuthSession } from "aws-amplify/auth";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Map, { FullscreenControl, useMap } from "react-map-gl";
 import { VehicleState } from "../../models/VehicleState";
+import { PlaybackClock } from '../Utils/PlaybackClock';
 import { SpinnerLoading } from "../Utils/SpinnerLoading";
 import { Button, Card } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
@@ -10,6 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSatellite, faHome, faMap } from '@fortawesome/free-solid-svg-icons';
 import { ViewControl } from './ViewControl';
 import { CONFIG } from "../../config";
+import { usePlayback } from "../../context/PlaybackContext";
 
 export const DriverViewPage = () => {
   // Get the Vehicle ID from the URL in the window
@@ -27,10 +29,14 @@ export const DriverViewPage = () => {
   // Driver view offset from straight ahead
   const [degViewOffset, setDegViewOffset] = useState(0);
 
+  const { playbackOffset } = usePlayback();
+
   // Map style
   const MAP_STYLE_SATELLITE = "mapbox://styles/tarterwaresteve/cm518rzmq00fr01qpfkvcd4md";
   const MAP_STYLE_STREET = "mapbox://styles/mapbox/standard";
   const [mapStyle, setMapStyle] = useState(MAP_STYLE_SATELLITE);
+
+  const isFetchingRef = useRef(false);
 
   // Conversion from meters per second to miles per hour.
   const MPS_TO_MPH = 2.236936;
@@ -102,11 +108,19 @@ export const DriverViewPage = () => {
   }, [degViewOffset, driverViewPageMap, getCoordinateAtBearingAndRange]);
 
   const fetchVehicleState = useCallback(() => {
-    if (!token) return;
+    if (!token || (playbackOffset === null) || isFetchingRef.current) return;
+
+    isFetchingRef.current = true;
 
     // Get the latest VehicleState
     const restUrlBase = CONFIG.ROADRUNNER_REST_URL_BASE;
-    const getStatesUrl: string = `${restUrlBase}/api/vehicle/get-vehicle-state/${vehicleId}`;
+    let getStatesUrl: string = `${restUrlBase}/api/playback/get-vehicle-state?vehicleId=${vehicleId}`;
+    // If we are in playback mode, calculate the target timestamp
+    if (playbackOffset !== 0) {
+      const targetDate = new Date(Date.now() - playbackOffset);
+      const isoTimestamp = targetDate.toISOString();
+      getStatesUrl += `&timestamp=${encodeURIComponent(isoTimestamp)}`;
+    }
     fetch(getStatesUrl, {
       method: 'get',
       headers: { Authorization: `Bearer ${token}` },
@@ -127,8 +141,11 @@ export const DriverViewPage = () => {
         console.error(`Error during fetchVehicleState: ${error.message}`);
         setIsDataLoaded(false);
         gotoHomePage();
+      })
+            .finally(() => {
+        isFetchingRef.current = false;
       });
-  }, [token, vehicleId, gotoHomePage, updateMapView]);
+  }, [token, vehicleId, gotoHomePage, updateMapView, playbackOffset]);
 
   useEffect(() => {
     const intervalId = setInterval(() => {
@@ -145,7 +162,6 @@ export const DriverViewPage = () => {
 
   const onMapLoad = useCallback(() => {
     const timer = setTimeout(() => {
-      console.log("onMapLoad()");
       const map = driverViewPageMap?.getMap();
       const layers = map?.getStyle()?.layers;
       if (layers) {
@@ -193,6 +209,7 @@ export const DriverViewPage = () => {
             maxZoom={24}
             onLoad={onMapLoad}
           >
+            <PlaybackClock />
             <div style={{ position: "fixed", top: 10, left: 10 }}>
               <Button onClick={gotoHomePage}>
                 <FontAwesomeIcon icon={faHome} className="mr-3" />

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -6,6 +6,7 @@ import { VehicleIcon } from './VehicleIcon';
 import { VehicleDisplay } from '../../models/VehicleDisplay';
 import { VehicleState } from '../../models/VehicleState';
 import { MapWrapper } from '../Utils/MapWrapper';
+import { PlaybackClock } from '../Utils/PlaybackClock';
 import { AppNavBar } from '../NavBar/AppNavBar';
 import { ManageMenu } from './ManageMenu';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -15,6 +16,7 @@ import { CreateVehiclePanel } from './CreateVehiclePanel';
 import { SimulationTable } from './SimulationTable';
 import { fetchAuthSession, signInWithRedirect } from "aws-amplify/auth";
 import { CONFIG } from "../../config";
+import { usePlayback } from "../../context/PlaybackContext";
 
 export const HomePage = () => {
   const { homePageMap } = useMap();
@@ -32,6 +34,9 @@ export const HomePage = () => {
 
   const vehicleStateMapRef = useRef(new MapWrapper<string, VehicleState>());
   const vehicleDisplayMapRef = useRef(new MapWrapper<string, VehicleDisplay>());
+  const isFetchingRef = useRef(false);
+
+  const { playbackOffset, clearPlayback } = usePlayback();
 
   // Map styles
   const MAP_STYLE_SATELLITE = "mapbox://styles/tarterwaresteve/cm518rzmq00fr01qpfkvcd4md";
@@ -99,20 +104,26 @@ export const HomePage = () => {
   }
 
   const fetchVehicleStateList = useCallback(() => {
-    if (!token || !isMapLoaded) return;
+    if (!token || !isMapLoaded || isFetchingRef.current) return;
 
+    isFetchingRef.current = true;
 
-    // Remove Vehicles from the Map that haven't been updated in SECS_VEHICLE_TIMEOUT seconds
-    const msEpochTimeoutTime = Date.now() - (SECS_VEHICLE_TIMEOUT * 1000);
+    // Timeout vehicles if they haven't updated lately
+    const msEpochTimeoutTime = Date.now() - (SECS_VEHICLE_TIMEOUT * 1000) - playbackOffset;
     vehicleStateMapRef.current = vehicleStateMapRef.current.filter(
       state => state.msEpochLastRun > msEpochTimeoutTime
     );
 
     // Get the latest VehicleStates
     const restUrlBase = CONFIG.ROADRUNNER_REST_URL_BASE;
+    let getStatesUrl = `${restUrlBase}/api/playback/state?page=${pageNumber}`;
 
-    // Add page and pageSize parameters to the query string
-    const getStatesUrl: string = `${restUrlBase}/api/vehicle/get-all-vehicle-states?page=${pageNumber}`;
+    // Calculate the target timestamp, if needed
+    if (playbackOffset !== 0) {
+      const targetDate = new Date(Date.now() - playbackOffset);
+      const isoTimestamp = targetDate.toISOString();
+      getStatesUrl += `&timestamp=${encodeURIComponent(isoTimestamp)}`;
+    }
 
     fetch(getStatesUrl, {
       method: 'get',
@@ -142,8 +153,11 @@ export const HomePage = () => {
       .catch(error => {
         console.log(`Error caught during fetch in fetchVehicleStateList: ${error.message}`);
         setIsDataLoaded(false);
+      })
+      .finally(() => {
+        isFetchingRef.current = false;
       });
-  }, [token, isMapLoaded, pageNumber, vehicleSize]);
+  }, [token, isMapLoaded, pageNumber, vehicleSize, playbackOffset]);
 
   useEffect(() => {
     if (!isMapLoaded) return;
@@ -220,7 +234,6 @@ export const HomePage = () => {
   }, []);
 
   const onClick = useCallback((event: any) => {
-    console.log("onClick()");
     let bestVehicle: VehicleDisplay | undefined = {} as VehicleDisplay;
     let bestDistance = 100;
     vehicleStateMapRef.current.forEach((vehicleState: VehicleState) => {
@@ -247,7 +260,6 @@ export const HomePage = () => {
 
   const onLoad = useCallback(() => {
     setIsMapLoaded(true);
-    console.log("Map loaded");
   }, []);
 
   const openCreateVehicle = useCallback(() => {
@@ -257,6 +269,12 @@ export const HomePage = () => {
   const toggleSimTable = useCallback(() => {
     setShowSimTable(!showSimTable);
   }, [showSimTable]);
+
+  const returnToNow = useCallback(() => {
+    clearPlayback();
+    vehicleStateMapRef.current.clear();
+    setVehicleStateMapVersion(v => v + 1);
+  }, [clearPlayback]);
 
   return (
     <>
@@ -278,6 +296,7 @@ export const HomePage = () => {
           <AppNavBar additionalMenuItems={<ManageMenu openCreateVehicle={openCreateVehicle} toggleSimTable={toggleSimTable} />} />
           {(isDataLoaded && !isTransitioning) ?
             <>
+              <PlaybackClock />
               {isCreateVehicleActive && (
                 <CreateVehiclePanel
                   setIsCreateVehicleActive={setIsCreateVehicleActive}
@@ -309,7 +328,7 @@ export const HomePage = () => {
                   <FontAwesomeIcon title="Hide All Routes" icon={faEyeSlash} className="mr-3" />
                 </Button>
               </div>
-              {showSimTable && <SimulationTable />}
+              {showSimTable && <SimulationTable toggleSimTable={toggleSimTable} returnToNow={returnToNow}/>}
               {vehicleStateList.map((vehicleState) => {
                 const vehicleDisplay = vehicleDisplayMapRef.current.get(vehicleState.id);
                 if (vehicleDisplay) {

--- a/src/components/HomePage/ManageMenu.tsx
+++ b/src/components/HomePage/ManageMenu.tsx
@@ -69,7 +69,7 @@ export const ManageMenu = (props: {
   };
 
   const handleResetServer = async () => {
-    const url = `${CONFIG.ROADRUNNER_REST_URL_BASE}/api/vehicle/reset-server`;
+    const url = `${CONFIG.ROADRUNNER_REST_URL_BASE}/api/vehicle/reset-server-INHIBITTED`;
     try {
       const response = await fetch(url, {
         method: 'get',

--- a/src/components/HomePage/SimulationTable.tsx
+++ b/src/components/HomePage/SimulationTable.tsx
@@ -2,12 +2,23 @@ import { fetchAuthSession } from "aws-amplify/auth";
 import { useMemo, useState, useEffect } from 'react';
 import { MaterialReactTable } from 'material-react-table';
 import { CONFIG } from "../../config";
+import { usePlayback } from "../../context/PlaybackContext";
+import { Button } from "react-bootstrap";
 
-export const SimulationTable = () => {
+export const SimulationTable = (props: {
+  toggleSimTable: any,
+  returnToNow: any,
+}) => {
   const [token, setToken] = useState("");
   const [data, setData] = useState([]);
   const [rowCount, setRowCount] = useState(0);
-  const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
+
+  const { playbackOffset } = usePlayback();
+
+  const [pagination, setPagination] = useState({
+    pageIndex: 0,
+    pageSize: 10
+  });
 
   // Load (and silently refresh) an access token
   useEffect(() => {
@@ -38,38 +49,119 @@ export const SimulationTable = () => {
   useEffect(() => {
     if (!token) return;
 
-    const url=`${CONFIG.ROADRUNNER_REST_URL_BASE}/api/vehicle/simulation-sessions?page=${pagination.pageIndex}&size=${pagination.pageSize}`
-    fetch(url,{
-        method: 'get',
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+    const controller = new AbortController();
+
+    async function loadPage() {
+      try {
+        const url =
+          `${CONFIG.ROADRUNNER_REST_URL_BASE}` +
+          `/api/vehicle/simulation-sessions?page=${pagination.pageIndex}&pageSize=${pagination.pageSize}`
+
+        const res = await fetch(url, {
+          method: 'GET',
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          signal: controller.signal,
+        });
+
+        const pagedModel = await res.json();
+        const sessions = pagedModel._embedded?.simulationSessions ?? [];
+
+        setData(sessions);
+        setRowCount(pagedModel.page?.totalElements ?? 0);
+      } catch (err:any) {
+        if (err.name !== "AbortError") {
+          console.error("Fetch error:", err);
         }
-      })
-      .then(res => res.json())
-      .then(pagedModel => {
-        // Extract data from the HAL structure we fixed in the tests!
-        setData(pagedModel._embedded?.simulationSessions ?? []);
-        setRowCount(pagedModel.page.totalElements);
-      });
-  }, [pagination.pageIndex, pagination.pageSize, token]);
+      }
+    }
+
+    loadPage();
+
+    return () => controller.abort();
+  }, [token, pagination.pageIndex, pagination.pageSize]);
 
   const columns = useMemo(() => [
     { accessorKey: 'id', header: 'Session ID' },
     { accessorKey: 'start', header: 'Start Time' },
-    { accessorKey: 'end', header: 'End Time' },
-  ], []);
+    {
+      header: 'Actions',
+      Cell: ({ row }: any) => {
+        const { setPlaybackSession } = usePlayback();
+        return (
+          <Button
+           size="sm"
+           onClick={() => {
+            setPlaybackSession(row.original.start);
+            props.toggleSimTable();
+          }}>
+            ▶️ Playback
+          </Button>
+        );
+      }
+    }
+  ], [props]);
 
   return (
-    <MaterialReactTable
-      columns={columns}
-      data={data}
-      manualPagination // Tells MRT NOT to do client-side paging
-      onPaginationChange={setPagination}
-      rowCount={rowCount}
-      state={{ pagination }}
-      enableRowVirtualization // Enables the high-performance scroll
-      muiTableContainerProps={{ sx: { maxHeight: '500px' } }} // Sets the scrollable area
-    />
+    <div
+      className="simulation-table-container"
+      style={{
+        position: 'relative',
+        zIndex: 1000, // Ensure it's above the Map layers
+        background: 'white',
+        padding: '10px',
+        borderRadius: '8px',
+        paddingBottom: '65px'
+      }}
+    >
+      {/* Show the button only if we are currently in playback mode */}
+      {playbackOffset !== 0 && (
+        <Button
+          variant="warning"
+          className="mb-2"
+          onClick={() => {
+            props.returnToNow();
+            props.toggleSimTable();
+          }}
+          style={{
+            position: 'relative',
+            zIndex: 1001,
+            display: 'block', // Ensure it takes up its own line
+            width: '100%'
+          }}
+        >
+          Return to Current Time (Live)
+        </Button>
+      )}
+      <MaterialReactTable
+        columns={columns}
+        data={data}
+        manualPagination // Tells MRT NOT to do client-side paging
+        rowCount={rowCount}
+        onPaginationChange={setPagination}
+        state={{
+          pagination,
+         }}
+        muiTableContainerProps={{ sx: { maxHeight: '400px' } }} // Sets the scrollable area
+        initialState={{ density: 'compact' }}
+      />
+      <Button
+        variant="warning"
+        className="mb-2"
+        onClick={() => {
+          props.toggleSimTable();
+        }}
+        style={{
+          position: 'absolute',
+          bottom: '10px',
+          right: '10px',
+          zIndex: 1001,
+        }}
+      >
+        Close
+      </Button>
+    </div>
   );
 };

--- a/src/components/Utils/PlaybackClock.tsx
+++ b/src/components/Utils/PlaybackClock.tsx
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { usePlayback } from '../../context/PlaybackContext';
+import { Badge } from 'react-bootstrap';
+
+export const PlaybackClock = () => {
+  const { playbackOffset } = usePlayback();
+  const [displayTime, setDisplayTime] = useState<string>("");
+
+  useEffect(() => {
+    const updateClock = () => {
+      // Calculate time: Current wall clock - the historical offset
+      const targetDate = new Date(Date.now() - playbackOffset);
+      setDisplayTime(targetDate.toISOString());
+    };
+
+    // Initialize and set interval
+    updateClock();
+    const interval = setInterval(updateClock, 1000);
+
+    return () => clearInterval(interval);
+  }, [playbackOffset]);
+
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: '20px',
+      right: '20px',
+      zIndex: 1000,
+      fontFamily: 'monospace'
+    }}>
+      <Badge bg={playbackOffset === 0 ? "success" : "warning"} style={{ fontSize: '1rem', padding: '10px' }}>
+        {playbackOffset === 0 ? "LIVE: " : "PLAYBACK: "}
+        {displayTime}
+      </Badge>
+    </div>
+  );
+};

--- a/src/context/PlaybackContext.tsx
+++ b/src/context/PlaybackContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface PlaybackContextType {
+  playbackOffset: number; // Offset in milliseconds
+  setPlaybackSession: (startTime: string) => void;
+  clearPlayback: () => void;
+}
+
+const PlaybackContext = createContext<PlaybackContextType | undefined>(undefined);
+
+export const PlaybackProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [playbackOffset, setPlaybackOffset] = useState<number>(() => {
+    const saved = localStorage.getItem('roadrunner_offset');
+    return saved ? parseInt(saved, 10) : 0;
+  });
+
+  const setPlaybackSession = (startTime: string) => {
+    const offset = Date.now() - new Date(startTime).getTime();
+    setPlaybackOffset(offset);
+    localStorage.setItem('roadrunner_offset', offset.toString());
+  };
+
+  const clearPlayback = () => {
+    setPlaybackOffset(0);
+    localStorage.removeItem('roadrunner_offset');
+  }
+
+  return (
+    <PlaybackContext.Provider value={{ playbackOffset, setPlaybackSession, clearPlayback }}>
+      {children}
+    </PlaybackContext.Provider>
+  );
+};
+
+export const usePlayback = () => {
+  const context = useContext(PlaybackContext);
+  if (!context) throw new Error("usePlayback must be used within PlaybackProvider");
+  return context;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import './index.css';
 import { App } from './App';
 import { BrowserRouter } from 'react-router-dom';
 import { MapProvider } from 'react-map-gl';
+import { PlaybackProvider } from './context/PlaybackContext';
 
 import { configureAmplify } from "./amplify-config";
 
@@ -16,7 +17,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <MapProvider>
     <BrowserRouter>
-      <App />
+      <PlaybackProvider>
+        <App />
+      </PlaybackProvider>
     </BrowserRouter>
   </MapProvider>
 );


### PR DESCRIPTION
Add flag to prevent initiating a fetch if a fetch is already in progress. Add PlaybackContext to share current playback state among components. Add Playback clock to display time, and whether the time is in the past. Inhibit reset-server from being invoked.
Fix simulationTable's page size controls.